### PR TITLE
calico-node, calico-kube-controller resource spec update

### DIFF
--- a/manifest/calico_3.13.4.yaml
+++ b/manifest/calico_3.13.4.yaml
@@ -645,6 +645,10 @@ spec:
           resources:
             requests:
               cpu: 250m
+              memory: 750Mi
+            limits:
+              cpu: 750m
+              memory: 2Gi
           livenessProbe:
             exec:
               command:
@@ -774,6 +778,13 @@ spec:
               command:
               - /usr/bin/check-status
               - -r
+          resources:
+            requests:
+              cpu: 30m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 300Gi
 
 ---
 


### PR DESCRIPTION
- calico-node, calico-kube-controller의 resource request, limit 값을 업데이트
    - calico-node request cpu: 250m memory: 750Mi limit cpu: 750m memory: 2Gi
    - calico-kube-controller request cpu: 30m memory: 100Mi limit cpu: 100m memory: 300Mi